### PR TITLE
Feature Enhancement: Session Logging on Reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <link rel="manifest" href="manifest.json" />
     <link rel="apple-touch-icon" href="logo240.png" />
+    <link rel="stylesheet" href="style.css" />
   </head>
   <body>
     <div class="main">
@@ -27,8 +28,19 @@
           value="Reset Timer"
         />
       </div>
+      <h3>Time Log</h3>
+      <table id="timeLogTable" border="1">
+        <thead>
+          <tr>
+            <th>Session</th>
+            <th>Duration</th>
+          </tr>
+        </thead>
+        <tbody id="timeLogBody">
+          <!-- Logs will be added here -->
+        </tbody>
+      </table>
     </div>
-    <link rel="stylesheet" href="style.css" />
     <script src="index.js"></script>
     <script src="pomodoro.js"></script>
   </body>

--- a/pomodoro.js
+++ b/pomodoro.js
@@ -3,6 +3,8 @@ const executeOrder66 = () => {
   const counterEl = document.getElementById("counter");
   const startButton = document.getElementById("startButton");
   const resetButton = document.getElementById("resetButton");
+  const timeLogTable = document.getElementById("timeLogBody"); // Table body for time logs
+
   const emojiArr = [
     "🙂",
     "😀",
@@ -22,29 +24,36 @@ const executeOrder66 = () => {
     "🥳",
     "🥳",
   ];
+
   const DEFAULT_START_SECONDS = 60 * 30;
   const DEFAULT_BREAK_SECONDS = 60 * 5;
   let seconds = DEFAULT_START_SECONDS;
   let startFilePlayed = false;
   let counter = 0;
   let timeout;
+  let sessionCount = 0; // To keep track of sessions
+  let sessionStartTime; // Track session start time
 
+  // Helper function to convert seconds to mm:ss format
   const changeOutput = (seconds) => {
     const mm = Math.floor(seconds / 60);
     const ss = seconds % 60;
     outputEl.value = `${mm < 10 ? "0" : ""}${mm}:${ss < 10 ? "0" : ""}${ss}`;
   };
 
+  // Update counter and emoji display
   const updateCounter = (cntr) => {
     counterEl.value = `${cntr} ${cntr < emojiArr.length ? emojiArr[cntr] : ""}`;
   };
 
+  // Play audio file function
   const playAudioFile = (file) => {
     var audio = new Audio(file);
     audio.play();
     startFilePlayed = true;
   };
 
+  // Timer function that runs every second
   const timer = () => {
     if (seconds > 0) {
       if (!startFilePlayed) {
@@ -64,17 +73,39 @@ const executeOrder66 = () => {
     }
   };
 
+  // Log session time to table
+  const logSession = (duration) => {
+    sessionCount++;
+    const row = timeLogTable.insertRow();
+    const cell1 = row.insertCell(0);
+    const cell2 = row.insertCell(1);
+    cell1.innerHTML = sessionCount; // Session number
+    cell2.innerHTML = duration; // Session duration
+  };
+
+  // Function to reset the timer
   const resetTimer = () => {
     clearTimeout(timeout);
+    // Calculate and log the session duration if session has started
+    if (sessionStartTime) {
+      const sessionDuration = (DEFAULT_START_SECONDS - seconds) / 60; // In minutes
+      const formattedDuration = `${sessionDuration.toFixed(2)} mins`;
+      logSession(formattedDuration);
+      sessionStartTime = null; // Reset session start time
+    }
+
     seconds = DEFAULT_START_SECONDS;
     startFilePlayed = false;
     outputEl.classList.remove("break");
     changeOutput(seconds);
   };
 
+  // Add event listeners
   startButton.addEventListener("click", () => {
-    resetTimer();
-    timer();
+    if (!sessionStartTime) {
+      sessionStartTime = new Date(); // Start tracking session time
+      timer();
+    }
   });
 
   resetButton.addEventListener("click", () => resetTimer());

--- a/style.css
+++ b/style.css
@@ -49,3 +49,23 @@ body {
 .break {
   color: var(--secondary-color-darker);
 }
+
+table {
+  width: 60%;
+  margin-top: 20px;
+  border-collapse: collapse;
+}
+
+table, th, td {
+  border: 1px solid #ddd;
+}
+
+th, td {
+  padding: 8px;
+  text-align: center;
+}
+
+th {
+  background-color: #6078ed;
+  color: white;
+}


### PR DESCRIPTION
This update introduces a session logging feature to the Pomodoro Timer, where a log entry is added only when the timer is reset. The session duration is calculated and displayed in a table, preventing the issue of adding incorrect session durations (like "0:0") when the timer is restarted.

**Key Changes:**
- **Session Start Tracking**: A new mechanism tracks the start time of a Pomodoro session, which is used to calculate the session duration upon resetting.
- **Table Log Display**: When the "Reset Timer" button is clicked, the difference between the start and reset times is logged and displayed in a new table.
- **Prevent Unintended Logging**: The "Start Timer" button no longer logs an entry with a duration of "0:0" upon restart, ensuring that sessions are only logged when the timer is explicitly reset.

This enhancement improves the usability of the Pomodoro Timer by keeping a history of timed sessions, enabling users to track their progress effectively.

Sample images :
![image](https://github.com/user-attachments/assets/0a6f3efc-148c-4f35-914e-7eb5c5bbebac)
![image](https://github.com/user-attachments/assets/cacc58f3-12ec-4b1b-a91f-56cac9c59ad7)
